### PR TITLE
fix: empty dav permissions

### DIFF
--- a/lib/Service/Remote/RemoteContactsService.php
+++ b/lib/Service/Remote/RemoteContactsService.php
@@ -341,10 +341,15 @@ class RemoteContactsService {
 
 		if (isset($so[RemoteClient::DAV_OWNER])) {
 			$owner = RemoteConvert::extractPrincipal($so[RemoteClient::DAV_OWNER]);
-			$permissions = RemoteConvert::extractPermissions($so[RemoteClient::DAV_ACL] ?? []);
+			$acl = $so[RemoteClient::DAV_ACL] ?? null;
 
-			if (isset($permissions[$owner])) {
-				$to->permissions = $permissions[$owner];
+			if (is_array($acl)) {
+				$permissions = RemoteConvert::extractPermissions($acl);
+				$to->permissions = $permissions[$owner] ?? [];
+			} elseif ($owner !== null && $owner === $this->dataStore->getPrincipalUrl()) {
+				// Server did not return ACL entries; infer owner-level permission from the
+				// {DAV:}all property when it matches the authenticated principal.
+				$to->permissions = ['{DAV:}all'];
 			} else {
 				$to->permissions = [];
 			}

--- a/lib/Service/Remote/RemoteEventsService.php
+++ b/lib/Service/Remote/RemoteEventsService.php
@@ -344,10 +344,15 @@ class RemoteEventsService {
 
 		if (isset($so[RemoteClient::DAV_OWNER])) {
 			$owner = RemoteConvert::extractPrincipal($so[RemoteClient::DAV_OWNER]);
-			$permissions = RemoteConvert::extractPermissions($so[RemoteClient::DAV_ACL] ?? []);
+			$acl = $so[RemoteClient::DAV_ACL] ?? null;
 
-			if (isset($permissions[$owner])) {
-				$to->permissions = $permissions[$owner];
+			if (is_array($acl)) {
+				$permissions = RemoteConvert::extractPermissions($acl);
+				$to->permissions = $permissions[$owner] ?? [];
+			} elseif ($owner !== null && $owner === $this->dataStore->getPrincipalUrl()) {
+				// Server did not return ACL entries; infer owner-level permission from the
+				// {DAV:}all property when it matches the authenticated principal.
+				$to->permissions = ['{DAV:}all'];
 			} else {
 				$to->permissions = [];
 			}


### PR DESCRIPTION
### Summary
- modified collection conversion logic to add default DAV:all if server returned no permissions

### Issue
- Some servers do not return permissions during propFind even when requested

<img width="556" height="247" alt="image" src="https://github.com/user-attachments/assets/5bae2b7d-9136-432c-afb9-cecb8aed7bfe" />


