### PR TITLE
fix: default empty service path to /.well-known/caldav

### DIFF
--- a/lib/Service/CoreService.php
+++ b/lib/Service/CoreService.php
@@ -91,7 +91,7 @@ class CoreService {
 		}
 
 		if (empty($configuration['location_path'])) {
-			$configuration['location_path'] = '.well-known/caldav';
+			$configuration['location_path'] = '/.well-known/caldav';
 		}
 
 		return $configuration;

--- a/lib/Service/Remote/RemoteClient.php
+++ b/lib/Service/Remote/RemoteClient.php
@@ -405,7 +405,7 @@ class RemoteClient {
 		return $response;
 	}
 
-	private function constructUrl(string $path = '/'): string {
+	private function constructUrl(?string $path = '/'): string {
 		$host = sprintf(
 			'%s://%s:%d',
 			$this->locationProtocol,
@@ -413,7 +413,7 @@ class RemoteClient {
 			$this->locationPort,
 		);
 		$host = rtrim($host, '/') . '/';
-		if ($path === '') {
+		if ($path === null || $path === '') {
 			$path = '/';
 		}
 


### PR DESCRIPTION
## Summary

- When no `location_path` is provided during service creation, the path was stored as `null`, causing a `TypeError` in `RemoteClient::constructUrl()` and leaving `calendars_url` unpopulated after discovery.
- Default the path to `/.well-known/caldav` in both `CoreService::connectAccount()` and as a fallback in `RemoteClient::discover()`.
- Fix an undefined array key PHP warning when the `auth` key is absent from the configuration array by using null-coalescing access.

Fixes #74

## Test plan

- Connect an account without providing an explicit service path
- Verify that discovery succeeds and calendars/contacts are populated correctly