### PR TITLE
fix: follow HTTP 301 redirects during DAV discovery

### DIFF
--- a/lib/Service/Remote/RemoteClient.php
+++ b/lib/Service/Remote/RemoteClient.php
@@ -438,6 +438,7 @@ class RemoteClient {
 			'headers' => $headers,
 			'timeout' => IClient::DEFAULT_REQUEST_TIMEOUT,
 			'verify' => $this->locationSecurity,
+			'allow_redirects' => ['strict' => true, 'max' => 5],
 		];
 
 		$options = array_merge($options, $additionalOptions);


### PR DESCRIPTION
## Summary

- Guzzle does not follow redirects for non-GET methods (PROPFIND, OPTIONS) by default.
- CalDAV well-known URIs (`/.well-known/caldav`) commonly respond with a 301 redirect to the actual endpoint (e.g. `/dav/calendars`). Without redirect support, the discovery PROPFIND never reached the real CalDAV path, leaving `principal_url` and `calendars_url` empty in the database.
- Enable strict redirect following (same HTTP method preserved) with a max of 5 hops for all requests built via `buildOptionsRequestOptions()`.

## Test plan

- Connect an account whose well-known CalDAV URL returns a 301 redirect
- Verify that discovery completes successfully and calendars are listed