### PR TITLE
fix: handle undeclared XML namespace prefixes in PROPFIND responses

### DIFF
--- a/lib/Service/Remote/RemoteClient.php
+++ b/lib/Service/Remote/RemoteClient.php
@@ -563,8 +563,16 @@ class RemoteClient {
 			return [];
 		}
 
-		/** @var MultiStatus $multistatus */
-		$multistatus = (new SabreXmlService())->expect(self::DAV_MULTISTATUS, $body);
+		try {
+			$multistatus = (new SabreXmlService())->expect(self::DAV_MULTISTATUS, $body);
+		} catch (ParseException $e) {
+			// Some servers (e.g. Fastmail/Cyrus IMAP) return XML containing namespace
+			// prefixes (e.g. CY:write-properties-resource) that are never declared with
+			// an xmlns attribute. Inject placeholder declarations so Sabre can parse the
+			// standard DAV properties we actually need, then retry.
+			$body = $this->declareUndeclaredNamespacePrefixes($body);
+			$multistatus = (new SabreXmlService())->expect(self::DAV_MULTISTATUS, $body);
+		}
 
 		$result = [];
 		foreach ($multistatus->getResponses() as $davResponse) {
@@ -575,6 +583,27 @@ class RemoteClient {
 		}
 
 		return $result;
+	}
+
+	private function declareUndeclaredNamespacePrefixes(string $xml): string {
+		preg_match_all('/<(?![\?!\/])([a-zA-Z][a-zA-Z0-9_-]*):/', $xml, $usedMatches);
+		$usedPrefixes = array_unique(array_filter($usedMatches[1]));
+
+		preg_match_all('/\bxmlns:([a-zA-Z][a-zA-Z0-9_-]*)\s*=/', $xml, $declaredMatches);
+		$declaredPrefixes = array_flip($declaredMatches[1]);
+
+		$extra = '';
+		foreach ($usedPrefixes as $prefix) {
+			if (!isset($declaredPrefixes[$prefix])) {
+				$extra .= sprintf(' xmlns:%s="urn:unknown-ns:%s"', $prefix, $prefix);
+			}
+		}
+
+		if ($extra === '') {
+			return $xml;
+		}
+
+		return preg_replace('/(<[a-zA-Z:][^>]*?)(\s*\/?>)/', '$1' . $extra . '$2', $xml, 1);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Fastmail (Cyrus IMAP backend) includes proprietary elements such as `CY:write-properties-resource` in CalDAV PROPFIND responses without declaring the `CY` namespace prefix.
- This causes Sabre's strict XML parser to throw a `LibXMLException` before any standard DAV properties can be extracted, breaking harmonization for all Fastmail-hosted calendars and address books.
- On `ParseException`, the fix collects all undeclared namespace prefixes from the response XML, injects placeholder URN declarations into the root element, then retries parsing. The placeholder namespaces are ignored by the harmonization logic since only well-known DAV/CalDAV/CardDAV properties are consumed.

## Test plan

- Connect a Fastmail (or other Cyrus IMAP) account
- Trigger harmonization and verify calendars and contacts sync without XML parse errors in the log