### PR TITLE
fix: always release collection lock after harmonization

### DIFF
--- a/lib/Service/ContactsService.php
+++ b/lib/Service/ContactsService.php
@@ -69,23 +69,25 @@ class ContactsService {
 			}
 			$collection->setHlockhd((int)getmypid());
 			$collection = $this->localStore->collectionModify($collection);
-			// execute harmonization loop
-			do {
-				// update lock heartbeat
+			try {
+				// execute harmonization loop
+				do {
+					// update lock heartbeat
+					$collection->setHlockhb(time());
+					$collection = $this->localStore->collectionModify($collection);
+					// harmonize collection
+					$statistics = $this->harmonizeCollection($collection);
+					// evaluate if anything was done and publish notice if needed
+					if ($statistics->total() > 0) {
+						//$this->CoreService->publishNotice($uid,'Contacts_harmonized', (array)$statistics);
+					}
+				} while ($statistics->total() > 0);
+			} finally {
+				// always release the lock, even when an exception aborts the loop
 				$collection->setHlockhb(time());
-				$collection = $this->localStore->collectionModify($collection);
-				// harmonize collection
-				$statistics = $this->harmonizeCollection($collection);
-				// evaluate if anything was done and publish notice if needed
-				if ($statistics->total() > 0) {
-					//$this->CoreService->publishNotice($uid,'Contacts_harmonized', (array)$statistics);
-				}
-			} while ($statistics->total() > 0);
-			// update harmonization time stamp
-			$collection->setHlockhb(time());
-			// unlock correlation after harmonization
-			$collection->setHlock(0);
-			$collection = $this->localStore->collectionModify($collection);
+				$collection->setHlock(0);
+				$this->localStore->collectionModify($collection);
+			}
 		}
 
 	}

--- a/lib/Service/EventsService.php
+++ b/lib/Service/EventsService.php
@@ -69,23 +69,25 @@ class EventsService {
 			}
 			$collection->setHlockhd((int)getmypid());
 			$collection = $this->localStore->collectionModify($collection);
-			// execute harmonization loop
-			do {
-				// update lock heartbeat
+			try {
+				// execute harmonization loop
+				do {
+					// update lock heartbeat
+					$collection->setHlockhb(time());
+					$collection = $this->localStore->collectionModify($collection);
+					// harmonize collection
+					$statistics = $this->harmonizeCollection($collection);
+					// evaluate if anything was done and publish notice if needed
+					if ($statistics->total() > 0) {
+						//$this->CoreService->publishNotice($uid,'Contacts_harmonized', (array)$statistics);
+					}
+				} while ($statistics->total() > 0);
+			} finally {
+				// always release the lock, even when an exception aborts the loop
 				$collection->setHlockhb(time());
-				$collection = $this->localStore->collectionModify($collection);
-				// harmonize collection
-				$statistics = $this->harmonizeCollection($collection);
-				// evaluate if anything was done and publish notice if needed
-				if ($statistics->total() > 0) {
-					//$this->CoreService->publishNotice($uid,'Contacts_harmonized', (array)$statistics);
-				}
-			} while ($statistics->total() > 0);
-			// update harmonization time stamp
-			$collection->setHlockhb(time());
-			// unlock correlation after harmonization
-			$collection->setHlock(0);
-			$collection = $this->localStore->collectionModify($collection);
+				$collection->setHlock(0);
+				$this->localStore->collectionModify($collection);
+			}
 		}
 
 	}


### PR DESCRIPTION
## Summary

- The harmonization lock was never released when an exception aborted the `do-while` loop (e.g. an XML parse error mid-sync).
- The stuck lock would then block all subsequent harmonization attempts for up to one hour, leaving collections silently stale with no visible error.
- Wrap the harmonization loop in `try/finally` in both `EventsService` and `ContactsService` so the lock is unconditionally cleared on exit, regardless of whether the loop completed normally or threw.

## Test plan

- Trigger a harmonization that throws mid-loop (e.g. by having the XML namespace fix disabled temporarily)
- Verify that the lock is released and a subsequent harmonization run starts within the normal interval