### PR TITLE
feat: auto-select first account on settings page load

### DIFF
--- a/src/views/UserSettings.vue
+++ b/src/views/UserSettings.vue
@@ -12,7 +12,7 @@ import { showError, showSuccess } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
 import { translatePlural as n, translate as t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
-import { onMounted, reactive, ref } from 'vue'
+import { nextTick, onMounted, reactive, ref } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
 import AccountRemoveIcon from 'vue-material-design-icons/AccountMinus.vue'
@@ -64,8 +64,12 @@ const eventsRemoteCollections = ref<Collection[]>([])
 const eventsLocalCollections = ref<Collection[]>([])
 
 // Lifecycle
-onMounted(() => {
-	serviceList()
+onMounted(async () => {
+	await serviceList()
+	if (selectedService.value === null && configuredServices.value.length === 1) {
+		await nextTick()
+		await serviceSelect(configuredServices.value[0])
+	}
 })
 
 // Methods


### PR DESCRIPTION
## Summary

- When opening the DAV connector settings page, the dropdown was empty and the user had to manually pick an account before any collection details were shown.
- The first configured account is now automatically selected on mount and its collections are loaded immediately.
- Uses `nextTick()` to ensure Vue has registered the options in `NcSelect` before the programmatic selection runs.

## Test plan

- Open the DAV connector settings page with at least one configured account
- Verify that the first account is pre-selected and its calendars/contacts collections are shown without any manual interaction