### PR TITLE
fix: use correct Content-Type for vCard PUT requests

### DIFF
--- a/lib/Service/Remote/RemoteContactsService.php
+++ b/lib/Service/Remote/RemoteContactsService.php
@@ -277,7 +277,7 @@ class RemoteContactsService {
 		}
 		$data = $so->data;
 
-		$result = $this->dataStore->create($path, $data, 'application/vcard');
+		$result = $this->dataStore->create($path, $data, 'text/vcard; charset=utf-8');
 
 		$ro = clone $so;
 		// persist the full resource path so the stored identifier matches what a
@@ -300,7 +300,7 @@ class RemoteContactsService {
 		}
 		$data = $so->data;
 
-		$result = $this->dataStore->update($path, $data, 'application/vcard');
+		$result = $this->dataStore->update($path, $data, 'text/vcard; charset=utf-8');
 
 		$ro = clone $so;
 		$ro->remoteSignature = $result['etag'] ?? null;


### PR DESCRIPTION
## Summary

- RFC 6350 defines the media type for vCard data as `text/vcard`, not `application/vcard`.
- `application/vcard` is not a valid MIME type and causes CardDAV servers that strictly validate the Content-Type (e.g. Fastmail/Cyrus IMAP) to reject PUT requests with `403 Forbidden` and a `<C:supported-address-data>` precondition error.
- This left newly created or modified contacts in Nextcloud without being synced to the remote server, while the Contacts app showed "Kontakt konnte nicht aktualisiert werden".
- `RemoteEventsService` already correctly uses `text/calendar; charset=utf-8` for iCalendar — this fix brings `RemoteContactsService` in line for vCard.

## Test plan

- Connect a Fastmail (or other strict CardDAV) account and enable an address book
- Create or edit a contact in Nextcloud Contacts within the synced address book
- Verify the contact is pushed to the remote server without a 403 error