### PR TITLE
feat: add unified search provider for DAV Connector events

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\DAVC\AppInfo;
 
 use OCA\DAVC\Events\UserDeletedListener;
+use OCA\DAVC\Search\EventsSearchProvider;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -32,6 +33,9 @@ class Application extends App implements IBootstrap {
 
 	#[\Override]
 	public function register(IRegistrationContext $context): void {
+
+		// register search provider so DAV Connector events appear in unified search
+		$context->registerSearchProvider(EventsSearchProvider::class);
 
 		// register event handlers
 		$dispatcher = $this->getContainer()->get(IEventDispatcher::class);

--- a/lib/Search/EventsSearchProvider.php
+++ b/lib/Search/EventsSearchProvider.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAVC\Search;
+
+use DateTime;
+use DateTimeZone;
+use OCP\IDBConnection;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\Search\IProvider;
+use OCP\Search\ISearchQuery;
+use OCP\Search\SearchResult;
+use OCP\Search\SearchResultEntry;
+
+class EventsSearchProvider implements IProvider {
+
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly IURLGenerator $urlGenerator,
+		private readonly IL10N $l10n,
+	) {
+	}
+
+	#[\Override]
+	public function getId(): string {
+		return 'davc-events';
+	}
+
+	#[\Override]
+	public function getName(): string {
+		return $this->l10n->t('DAV Connector Events');
+	}
+
+	#[\Override]
+	public function getOrder(string $route, array $routeParameters): ?int {
+		return 31;
+	}
+
+	#[\Override]
+	public function search(IUser $user, ISearchQuery $query): SearchResult {
+		$term = $query->getFilter('term')?->get();
+		if ($term === null || $term === '') {
+			return SearchResult::complete($this->getName(), []);
+		}
+
+		$limit = $query->getLimit();
+		$offset = (int)($query->getCursor() ?? 0);
+
+		$likeTerm = '%' . $this->db->escapeLikeParameter($term) . '%';
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select(
+				'e.uuid', 'e.label', 'e.description', 'e.startson', 'e.endson',
+				'c.uuid AS collection_uuid', 'c.label AS collection_label',
+			)
+			->from('davc_entities_calendars', 'e')
+			->innerJoin('e', 'davc_collections', 'c', $qb->expr()->eq('e.cid', 'c.id'))
+			->where($qb->expr()->eq('e.uid', $qb->createNamedParameter($user->getUID())))
+			->andWhere($qb->expr()->orX(
+				$qb->expr()->like('e.label', $qb->createNamedParameter($likeTerm)),
+				$qb->expr()->like('e.description', $qb->createNamedParameter($likeTerm)),
+			))
+			->orderBy('e.startson', 'ASC')
+			->setMaxResults($limit)
+			->setFirstResult($offset);
+
+		$since = $query->getFilter('since')?->get();
+		$until = $query->getFilter('until')?->get();
+		if ($since instanceof \DateTimeInterface) {
+			$qb->andWhere($qb->expr()->gte('e.endson', $qb->createNamedParameter($since->format('U'))));
+		}
+		if ($until instanceof \DateTimeInterface) {
+			$qb->andWhere($qb->expr()->lte('e.startson', $qb->createNamedParameter($until->format('U'))));
+		}
+
+		$result = $qb->executeQuery();
+		$entries = [];
+		while ($row = $result->fetch()) {
+			$entries[] = $this->rowToResult($row, $user->getUID());
+		}
+		$result->closeCursor();
+
+		return SearchResult::paginated(
+			$this->getName(),
+			$entries,
+			$offset + count($entries),
+		);
+	}
+
+	private function rowToResult(array $row, string $uid): SearchResultEntry {
+		$title = $row['label'] ?? $this->l10n->t('Untitled event');
+		$subline = ($row['collection_label'] ?? '') . ' · ' . $this->formatDatetime((int)$row['startson']);
+
+		$davUrl = $this->urlGenerator->linkTo('', 'remote.php')
+			. '/dav/calendars/' . urlencode($uid)
+			. '/app-generated--integration_davc--' . $row['collection_uuid']
+			. '/' . $row['uuid'];
+
+		$resourceUrl = $this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->linkToRoute('calendar.view.index')
+			. 'edit/' . base64_encode($davUrl)
+		);
+
+		$entry = new SearchResultEntry('', $title, $subline, $resourceUrl, 'icon-calendar-dark', false);
+		$entry->addAttribute('createdAt', (string)$row['startson']);
+
+		return $entry;
+	}
+
+	private function formatDatetime(int $timestamp): string {
+		$dt = new DateTime('@' . $timestamp);
+		$dt->setTimezone(new DateTimeZone(date_default_timezone_get()));
+		return $this->l10n->l('datetime', $dt, ['width' => 'medium|short']);
+	}
+}

--- a/lib/Search/EventsSearchProvider.php
+++ b/lib/Search/EventsSearchProvider.php
@@ -65,8 +65,8 @@ class EventsSearchProvider implements IProvider {
 			->innerJoin('e', 'davc_collections', 'c', $qb->expr()->eq('e.cid', 'c.id'))
 			->where($qb->expr()->eq('e.uid', $qb->createNamedParameter($user->getUID())))
 			->andWhere($qb->expr()->orX(
-				$qb->expr()->like('e.label', $qb->createNamedParameter($likeTerm)),
-				$qb->expr()->like('e.description', $qb->createNamedParameter($likeTerm)),
+				$qb->expr()->iLike('e.label', $qb->createNamedParameter($likeTerm)),
+				$qb->expr()->iLike('e.description', $qb->createNamedParameter($likeTerm)),
 			))
 			->orderBy('e.startson', 'ASC')
 			->setMaxResults($limit)


### PR DESCRIPTION
## Summary

- Registers a new `OCP\\Search\\IProvider` (`EventsSearchProvider`) so DAV Connector calendar events appear in Nextcloud's unified search (top-right search bar)
- Queries `davc_entities_calendars` JOIN `davc_collections` directly for fast, user-scoped full-text search on event title and description
- Supports standard built-in filters (`term`, `since`, `until`) and pagination via cursor
- Result links open the Nextcloud Calendar app pointing to the matched event

## Test plan

- [ ] Search for a term that matches a DAV Connector event title (e.g. a person's name)
- [ ] Verify results appear in the unified search under "DAV Connector Events"
- [ ] Verify clicking a result opens the Calendar app
- [ ] Verify `since` / `until` date filters narrow results correctly
- [ ] Verify pagination works (scroll to load more results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)